### PR TITLE
Require Buffer module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const { Buffer } = require('buffer')
+
 module.exports = dist
 
 function dist (a, b) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "2.0.0",
   "description": "Calculate the distance between two buffers as a new buffer and compare computed distances with eachother",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "buffer": "^6.0.3"
+  },
   "devDependencies": {
     "tape": "^4.2.0"
   },


### PR DESCRIPTION
Recent bundlers don't include node globals in the bundles any more so this PR adds a dep on [Buffer](https://www.npmjs.com/package/buffer) in order to let this module be used in the browser.